### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,15 @@
-name: Deploy to GitHub Pages
-
+name: Deploy static site to GitHub Pages
 on:
   push:
-    branches: [ "main" ]
+    branches: [ store-layout ]
   workflow_dispatch:
-
 permissions:
   contents: read
   pages: write
   id-token: write
-
 concurrency:
   group: "pages"
-  cancel-in-progress: false
-
+  cancel-in-progress: true
 jobs:
   deploy:
     environment:
@@ -23,28 +19,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
-      - name: Prepare deployment
-        run: |
-          echo "🚀 Preparing deployment at $(date -u)"
-          echo "📁 Files to deploy:"
-          ls -la *.html
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: '.'
-
+          path: .
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        
-      - name: Post-deployment
-        run: |
-          echo "✅ Deployment completed successfully!"
-          echo "🌐 Site URL: ${{ steps.deployment.outputs.page_url }}"
-          echo "🔄 Changes should be visible within a few minutes"
-          echo "⏰ Deployed at: $(date -u)"


### PR DESCRIPTION
## Summary
- replace deployment workflow with minimal GitHub Pages action

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b2381a05748322b4a8d612dc924fb5