### PR TITLE
Improve mobile navigation and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ hr{border:none;border-top:1px solid var(--border);margin:16px 0}
   background:rgba(15,23,42,.85); backdrop-filter:saturate(180%) blur(8px);
   border-bottom:1px solid rgba(255,255,255,.1); color:#fff;
 }
-.header .row{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:12px 0}
+.header .row{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:12px 0;position:relative}
 .brand{display:flex;align-items:center;gap:12px}
 .brand .logo{
   width:48px; height:48px;
@@ -103,15 +103,58 @@ hr{border:none;border-top:1px solid var(--border);margin:16px 0}
     max-width: 100%;
     height: auto;
 }
-.nav{display:none;gap:28px;font-size:15px}
-.nav a{color:#cbd5e1; position:relative; padding:4px 0;}
+.nav{
+    display:none;
+    flex-direction:column;
+    gap:16px;
+    font-size:15px;
+    position:absolute;
+    top:100%;
+    right:0;
+    left:0;
+    background:rgba(15,23,42,0.95);
+    padding:16px;
+    border-top:1px solid rgba(255,255,255,.1);
+    align-items:center;
+}
+.nav.open{display:flex}
+.nav a{color:#cbd5e1; position:relative; padding:8px 0; width:100%; text-align:center;}
 .nav a:after{
     content:''; position:absolute; bottom:0; right:0;
     width:0; height:2px; background:var(--brand); transition:var(--transition);
 }
 .nav a:hover{color:#fff}
 .nav a.active:after, .nav a:hover:after{width:100%;}
-@media(min-width:992px){.nav{display:flex}}
+@media(min-width:992px){
+    .nav{
+        display:flex;
+        position:static;
+        flex-direction:row;
+        background:transparent;
+        padding:0;
+        border-top:none;
+        gap:28px;
+    }
+    .nav a{
+        width:auto;
+        padding:4px 0;
+        text-align:initial;
+    }
+}
+
+.menu-toggle{
+    background:none;
+    border:none;
+    color:#fff;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    cursor:pointer;
+}
+.menu-toggle i{width:24px;height:24px}
+@media(min-width:992px){.menu-toggle{display:none}}
+.header-cta{display:none}
+@media(min-width:992px){.header-cta{display:block}}
 .subnav{background:#fff;color:var(--dark);border-bottom:1px solid var(--border); display:none;}
 @media(min-width:992px){.subnav{display:block}}
 .subnav .row{display:flex;gap:24px;font-size:14px;padding:10px 0}
@@ -210,6 +253,13 @@ footer a:hover{color:var(--brand);}
 /* --- Animation --- */
 .fade-in{opacity:0; transform:translateY(20px); transition:opacity 0.6s ease-out, transform 0.6s ease-out;}
 .fade-in.visible{opacity:1; transform:translateY(0);}
+
+@media(max-width:768px){
+  .topbar .row{flex-direction:column;gap:4px;text-align:center;}
+  .footer-bottom{flex-direction:column;text-align:center;}
+  .section{padding:60px 0;}
+  .section-tight{padding:40px 0;}
+}
 </style>
 </head>
 <body>
@@ -239,6 +289,7 @@ footer a:hover{color:var(--brand);}
         <div class="small" style="color:#cbd5e1; font-size:12px;">تحت إشراف شركة المحامي محمد الفارس</div>
       </div>
     </a>
+    <button class="menu-toggle" aria-label="القائمة"><i data-lucide="menu"></i></button>
     <nav class="nav">
       <a href="index.html" class="active">الرئيسية</a>
       <a href="about.html">من نحن</a>
@@ -248,7 +299,7 @@ footer a:hover{color:var(--brand);}
       <a href="help.html">اتصل بنا</a>
       <a href="faq.html">الأسئلة الشائعة</a>
     </nav>
-    <div><a class="btn btn-primary" href="help.html">اطلب استشارة</a></div>
+    <div class="header-cta"><a class="btn btn-primary" href="help.html">اطلب استشارة</a></div>
   </div>
 </header>
 <div class="subnav">
@@ -479,11 +530,33 @@ function setupScrollAnimations() {
     });
 }
 
+function setupMobileMenu(){
+  const toggle=document.querySelector('.menu-toggle');
+  const nav=document.querySelector('.nav');
+  if(!toggle||!nav)return;
+  toggle.addEventListener('click',()=>{
+    nav.classList.toggle('open');
+    const icon=toggle.querySelector('i');
+    const isOpen=nav.classList.contains('open');
+    icon.setAttribute('data-lucide',isOpen?'x':'menu');
+    lucide.createIcons();
+  });
+  nav.querySelectorAll('a').forEach(link=>{
+    link.addEventListener('click',()=>{
+      nav.classList.remove('open');
+      const icon=toggle.querySelector('i');
+      icon.setAttribute('data-lucide','menu');
+      lucide.createIcons();
+    });
+  });
+}
+
 ready(()=>{
   lucide.createIcons();
   setupSliders();
   setupBackToTop();
   setupScrollAnimations();
+  setupMobileMenu();
 });
 </script>
 


### PR DESCRIPTION
## Summary
- Add responsive navigation with a mobile toggle button and hide desktop call-to-action on small screens
- Introduce mobile-specific media queries to stack header and footer elements and adjust section spacing
- Implement JavaScript to control the collapsible menu and update icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b30fe2f45083229fb020bfaa834f15